### PR TITLE
Add support for UltraStar rap and golden rap notes

### DIFF
--- a/libkaraokelyrics/lyricsparser_texts.cpp
+++ b/libkaraokelyrics/lyricsparser_texts.cpp
@@ -156,7 +156,7 @@ void LyricsParser_Texts::parseUStar( const QByteArray& data, LyricsLoader::Conta
         // We may fall-through, so no else
         if ( !header )
         {
-            if ( line[0] != 'E' && line[0] != ':' && line[0] != '*' && line[0] != 'F' && line[0] != '-' )
+            if ( !QString("E:*FRG-").contains(line[0]) )
                 throw( "Not a valid format");
 
             // End?
@@ -176,7 +176,7 @@ void LyricsParser_Texts::parseUStar( const QByteArray& data, LyricsLoader::Conta
             else
             {
                 // Lyrics
-                QRegularExpression regex( "^[*Ff:]\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)\\s*(.*)?$" );
+                QRegularExpression regex( "^[*FRG:]\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)\\s*(.*)?$" );
                 QRegularExpressionMatch match = regex.match( line );
 
                 if ( !match.hasMatch() )


### PR DESCRIPTION
Hi,
I've added support for UltraStar rap (R) and golden rap (G) notes as documented here https://usdx.eu/format/#notetypes.
Without this change the program is unable to play UltraStar songs with rap notes and fails with "exception Cannot find a matching music/lyric file"
